### PR TITLE
TokenProxyFactory add

### DIFF
--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -1,0 +1,702 @@
+{
+  "manifestVersion": "3.2",
+  "impls": {
+    "d881e35bde773ba7c4a7bc9072f05c0960d9070bef94ed561fccbd2e9778bc1e": {
+      "address": "0xf784709d2317D872237C4bC22f867d1BAe2913AB",
+      "txHash": "0x76f841233565ece0f6c7ca20f97fb44bf82d34d4b35461d46bcf4b9366a996a1",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../../../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:23"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../../../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:28"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../../../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "_allowances",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "_totalSupply",
+            "type": "t_uint256",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:41"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:42"
+          },
+          {
+            "contract": "ERC20Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)45_storage",
+            "src": "../../../@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:310"
+          },
+          {
+            "contract": "Power",
+            "label": "version",
+            "type": "t_string_storage",
+            "src": "Power.sol:13"
+          },
+          {
+            "contract": "Power",
+            "label": "maxExpArray",
+            "type": "t_array(t_uint256)128_storage",
+            "src": "Power.sol:39"
+          },
+          {
+            "contract": "ProductToken",
+            "label": "reserveBalance",
+            "type": "t_uint256",
+            "src": "ProductToken.sol:15"
+          },
+          {
+            "contract": "ProductToken",
+            "label": "reserveRatio",
+            "type": "t_uint32",
+            "src": "ProductToken.sol:18"
+          },
+          {
+            "contract": "ProductToken",
+            "label": "maxTokenCount",
+            "type": "t_uint32",
+            "src": "ProductToken.sol:21"
+          },
+          {
+            "contract": "ProductToken",
+            "label": "tradeinCount",
+            "type": "t_uint32",
+            "src": "ProductToken.sol:22"
+          },
+          {
+            "contract": "ProductToken",
+            "label": "supplyOffset",
+            "type": "t_uint32",
+            "src": "ProductToken.sol:23"
+          }
+        ],
+        "types": {
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_array(t_uint256)128_storage": {
+            "label": "uint256[128]"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  },
+  "proxies": [
+    {
+      "address": "0x038B86d9d8FAFdd0a02ebd1A476432877b0107C8",
+      "kind": "transparent",
+      "txHash": "0x4a9c78a36408c72940c0c748e9d528d0d10231d7e6da4e6571853a05979b35b1"
+    },
+    {
+      "address": "0xEcc0a6dbC0bb4D51E4F84A315a9e5B0438cAD4f0",
+      "kind": "transparent",
+      "txHash": "0x5c192c617d3f84ad59e1a06c3ae64412e48ee2e121836d04f261c036fcbc6cae"
+    },
+    {
+      "address": "0x7e35Eaf7e8FBd7887ad538D4A38Df5BbD073814a",
+      "kind": "transparent",
+      "txHash": "0x33d50f528522cbe486f5e918730b2e46940ec68023c93467be6220000eda0a20"
+    },
+    {
+      "address": "0xa4bcDF64Cdd5451b6ac3743B414124A6299B65FF",
+      "kind": "transparent",
+      "txHash": "0x4fa88fc6668b09e13771f8ca011fb06a2346550db2b2bb7121ecdc7e41d60144"
+    },
+    {
+      "address": "0x8456161947DFc1fC159A0B26c025cD2b4bba0c3e",
+      "kind": "transparent",
+      "txHash": "0x39e1de91c8df7a900c61c3f93c02fb1f0a60644fb71c4afc8f283736d8f75634"
+    },
+    {
+      "address": "0x06bA8d8af0dF898D0712DffFb0f862cC51AF45c2",
+      "kind": "transparent",
+      "txHash": "0x8964aa504edb49e2225e7f9eec5e4af188b04c9f0418b66c0b74c4e81e866c56"
+    },
+    {
+      "address": "0xe1B3b8F6b298b52bCd15357ED29e65e66a4045fF",
+      "kind": "transparent",
+      "txHash": "0x5d6ca8a3400d3ded037e08f10368b3f5a2f86be6bf7726dcc821236685163c3b"
+    },
+    {
+      "address": "0x00aD4926D7613c8e00cB6CFa61831D5668265724",
+      "kind": "transparent",
+      "txHash": "0xa5725483b38781e46d22dbac5d9ee22ea3ff49bb948629048b1c9ac3d482542c"
+    },
+    {
+      "address": "0xA17827A991EB72793fa437e580B084ceB25Ab0f9",
+      "kind": "transparent",
+      "txHash": "0x697a354783c4fc2c9afced06159be975ec42f208b0dc03a73a2c674a89a760b4"
+    },
+    {
+      "address": "0x93C1e99C8dD990D77232821f9476c308FBad47f5",
+      "kind": "transparent",
+      "txHash": "0x12fb150d14bda459dccb7f3d4c246c880460e055d4fb739ed0019b5702ed1520"
+    },
+    {
+      "address": "0xecE50C63d1Ae02Ba306c2b2E1579d0327220196e",
+      "kind": "transparent",
+      "txHash": "0x23fe0ee0ae3d0adcdbe9aedb4dd8fc763262e334c9fa0c60268fb91721472c52"
+    },
+    {
+      "address": "0x053568617FFccEe2F75073975CC0e1549Ff9db71",
+      "kind": "transparent",
+      "txHash": "0x47bb1623e704170da4464c1836675fe3fab6b65dd91daee0d7f2f020bedb44af"
+    },
+    {
+      "address": "0xD036a8F254ef782cb93af4F829A1568E992c3864",
+      "kind": "transparent",
+      "txHash": "0x9ac4665e56de4e3e670b90f5d6bfa6c71fe8ae224707b77a09e1e05e87fda92b"
+    },
+    {
+      "address": "0xb81145Beaa1D00c6A99f8C342c6ce354019Ff737",
+      "kind": "transparent",
+      "txHash": "0xc8f61726e7f91973a4c7675d4ee56178e36196156c79ddbbe47f4b6b388a33fa"
+    },
+    {
+      "address": "0xc85759553AEE2D4125aFa8a9421AAf5397b96E6b",
+      "kind": "transparent",
+      "txHash": "0xcbaeaae7cd41210e39aec96692c1f935edf824f815277a78478d77f2297412c0"
+    },
+    {
+      "address": "0xFDAAc0fDAEBbe00B8A3EBB119367B6CF84E0F39c",
+      "kind": "transparent",
+      "txHash": "0xcf2c55237ace0e8fb2af7189e0af013a8e2d720b2d2db581dff91166fed7d232"
+    },
+    {
+      "address": "0xC26eFfa98B8A2632141562Ae7E34953Cfe5B4888",
+      "kind": "transparent",
+      "txHash": "0xfc8fb14aae975788b34eb9e8431622edc92d8e37bea5597be9b77bbfc9bac566"
+    },
+    {
+      "address": "0x4931b72A3f074A6c85DC62bBA648D7f4FBd1D0Ff",
+      "kind": "transparent",
+      "txHash": "0x70696043d8cc0a622238c2cdbb7eb237a43ac82b6e6925fcec15d976ad8d2fd7"
+    },
+    {
+      "address": "0xB30914453D4CeB5B9a3bD9460D039391D787D33f",
+      "kind": "transparent",
+      "txHash": "0x0998fadb144297a3a81e1cc756d296d230e2e2ed66958b9f2fb1c4ca875c2d84"
+    },
+    {
+      "address": "0x36e656E489918C3a5c58Be0551Fe12F3bF5E9830",
+      "kind": "transparent",
+      "txHash": "0x015c69dc5e129ad27948cbe98dd28aa8bd30d7ae276a58d2f9c7a287dfc6744a"
+    },
+    {
+      "address": "0xc11f8E173ee67ffA7BBdD185D2399994AAd23Ec6",
+      "kind": "transparent",
+      "txHash": "0x99f9cb84874460e6906185780466191999418ebfea5cd336c98cca473514c27d"
+    },
+    {
+      "address": "0x7B6C3e5486D9e6959441ab554A889099eed76290",
+      "kind": "transparent",
+      "txHash": "0x1765d2ee3c80e379580d13530074fbd521e7cb3a378b9fb291aa5967504bec78"
+    },
+    {
+      "address": "0xD83D2773a7873ae2b5f8Fb92097e20a8C64F691E",
+      "kind": "transparent",
+      "txHash": "0xd9293d3c573c0d0f86f6cb33e83b03d6dc546cd7e7fa30264805860ffe8a6523"
+    },
+    {
+      "address": "0xf91aC1098F3b154671Ce83290114aaE45ac0225f",
+      "kind": "transparent",
+      "txHash": "0x59cb37994b5f16468724dde50a8b8a21f25283cee8ad15fc9d11a6a7073acbc6"
+    },
+    {
+      "address": "0xf4830d6b1D70C8595d3BD8A63f9ed9F636DB9ef2",
+      "kind": "transparent",
+      "txHash": "0x1f3ffd326d4ae572c6ab81cd390ba1f921b9d0ade4b7bfb6f560dde78bc1ac37"
+    },
+    {
+      "address": "0xc1cb554de746224c13c1f25478aD0f3fa9e64843",
+      "kind": "transparent",
+      "txHash": "0xbe933aa09a5e0ffdbab5fb8240ccc3d4e633520cbeab31782ae59dca15e35d99"
+    },
+    {
+      "address": "0x8Dd7f10813aC8fCB83ad7ad94e941D53b002fBc7",
+      "kind": "transparent",
+      "txHash": "0xf6a308d7d111f26271a084a82e38c34ba42086a834bb17af57a104b15268c112"
+    },
+    {
+      "address": "0xCeEa6148D75268b6E930AE41d7a31baE1CA318d8",
+      "kind": "transparent",
+      "txHash": "0x528aa740d1cd5ab3c37c8da7fb505ea0412d05406c187d9d424955ff11088f09"
+    },
+    {
+      "address": "0x98B40aAC844674B2287556E75b3ef5530DfCfcB7",
+      "kind": "transparent",
+      "txHash": "0x28297d7941cb5f27b0890ce8a9b2322e00d5208722a57dd677d2ee08d254e145"
+    },
+    {
+      "address": "0xB529E6C14E73e8618f8e073368FAbd914bf96222",
+      "kind": "transparent",
+      "txHash": "0xc394f78d6a4b3468b7304e15417a706179c53dcb475c90fae90a700b2b85f6a0"
+    },
+    {
+      "address": "0x93472C0e03215F9c33DA240Eb16703C8244eAa8c",
+      "kind": "transparent",
+      "txHash": "0xd3d88f9b124ff9a1955bac5bded8471126287cb6601894fd3ad17854e63988a5"
+    },
+    {
+      "address": "0x72358bcB1b8B60Ca2f30244e50Be20C3ecaC74B2",
+      "kind": "transparent",
+      "txHash": "0xbf3fbf8ad80c258e8d9aa5b826faad387321578243c529e839248abf2e2edeea"
+    },
+    {
+      "address": "0xA13a6C2bD383EcBF8a7A6a6B3B7cfCff3C7C3407",
+      "kind": "transparent",
+      "txHash": "0x5f29a140e58350b94e6eb8807aa7ecb667fb957eb159bbda48e5701400d9520e"
+    },
+    {
+      "address": "0x689d0586F88cDEa1E1003F838DD943415E4EB1e5",
+      "kind": "transparent",
+      "txHash": "0xb663ecabc8f9bbf769fc8a2e157b2493926f4dc09f75986d8953baab0a6b35dc"
+    },
+    {
+      "address": "0xBAdDA897176B5A94FD4A0eCb59678DDA29181963",
+      "kind": "transparent",
+      "txHash": "0x04a134d40d954813c1e940f8b4a25ba9ed376f7f58ac8f3a75da666fb2f53d2c"
+    },
+    {
+      "address": "0x8D0206fEBEB380486729b64bB4cfEDC5b354a6D6",
+      "kind": "transparent",
+      "txHash": "0x95c1ec2134c37db4adb6be54251f8393a146a135fb4c8e5f9c62933c9e8eb5e8"
+    },
+    {
+      "address": "0xfC88832bac6AbdF216BC5A67be68E9DE94aD5ba2",
+      "kind": "transparent",
+      "txHash": "0x292870019fcd129d953420a829d0f64767af611c9eb6501b96a48504c16b6a70"
+    },
+    {
+      "address": "0x77B0b5636fEA30eA79BB65AeCCdb599997A849A8",
+      "kind": "transparent",
+      "txHash": "0x121d3692dfa88371e2c20cc4ed85beb17d29ec805b43ff8695ed4ddc42eae655"
+    },
+    {
+      "address": "0x920d847fE49E54C19047ba8bc236C45A8068Bca7",
+      "kind": "transparent",
+      "txHash": "0x0df4988d414b9562a3e406ba0334e6e5171d1a95a1fdc4cc4f09c68abd5a21ec"
+    },
+    {
+      "address": "0x35c1419Da7cf0Ff885B8Ef8EA9242FEF6800c99b",
+      "kind": "transparent",
+      "txHash": "0xfdadafeb4a7d115b914ddce589d2ba7b655c28d1d341fd8afc1731c26e487e37"
+    },
+    {
+      "address": "0xE55aA921A1001f0a19241264a50063683D2e1179",
+      "kind": "transparent",
+      "txHash": "0x077917bfa686a733859bb9d889ec16ded709667be7e82ad90729a6b22201ccef"
+    },
+    {
+      "address": "0xf89AA2f1397e9A0622c8Fc99aB1947E28b5EF876",
+      "kind": "transparent",
+      "txHash": "0xf0bd30a4790c9d0113b120fcdfc01d6b580d7457b9f78eea27b9b3eea6e3600e"
+    },
+    {
+      "address": "0x0EBCa695959e5f138Af772FAa44ce1A9C7aEd921",
+      "kind": "transparent",
+      "txHash": "0xa962b9b6de0693724639e0d828f7f89ff165bcbda4641fcae99fa1d82e4008f2"
+    },
+    {
+      "address": "0x8BFFF31B1757da579Bb5B118489568526F7fb6D4",
+      "kind": "transparent",
+      "txHash": "0xe7df0a6cd56aa66098b0b0ac8d7a0516e33ccda71d39439a3cbb3f1ded4f958d"
+    },
+    {
+      "address": "0x2530ce07D254eA185E8e0bCC37a39e2FbA3bE548",
+      "kind": "transparent",
+      "txHash": "0xd499bf5bce0413024490bbf4ec198bf1de9b9372a0923de5e3b8ad6a88de503b"
+    },
+    {
+      "address": "0x7fAeC7791277Ff512c41CA903c177B2Ed952dDAc",
+      "kind": "transparent",
+      "txHash": "0x89e57e04bd208ae84413ac849421fd3e751a2f18857c6509f051d228a4cbe081"
+    },
+    {
+      "address": "0x2cBbbBE1B75Ad7848F0844215816F551f429c64f",
+      "kind": "transparent",
+      "txHash": "0xc7c9274c04ddee221373d3512f1de673b29a49e94dac003aeb94f6e35b146042"
+    },
+    {
+      "address": "0xa43Ba00FCA75B805D17f67F9433b971E9a398690",
+      "kind": "transparent",
+      "txHash": "0x6fb0c333efb3e33e7bb8ab59206d61a959051fb4939197dfdde3f37a05b795a9"
+    },
+    {
+      "address": "0xadc8f433eA2371bE71D986d9B131892122969CA6",
+      "kind": "transparent",
+      "txHash": "0xe7ebad7ef73046a916ff566bec23a68ec4cb66ddfd17cb35c660713c17e67e48"
+    },
+    {
+      "address": "0x603A373A1571783bD82b708C20a5A4b019BAB78F",
+      "kind": "transparent",
+      "txHash": "0x35c954ab472e3fd53b9c9f8baa7a0cb90684914fcfaa2053673bed90d9e5cd89"
+    },
+    {
+      "address": "0x987D8EE0F70EdC8e9651c9E6a1618B8Bc8B9FB61",
+      "kind": "transparent",
+      "txHash": "0xa7be3a1fc34ff2c238fd4e60d0caf429e5df4fc4e7267fd29e75b1809957f80b"
+    },
+    {
+      "address": "0x3D0ED84712f1635e755870d63D9D30B33BaEaDc4",
+      "kind": "transparent",
+      "txHash": "0xfb1ea6e0f8820bae3c1a5b652601bc301be45e31d5417901c1e343dfe68ad83c"
+    },
+    {
+      "address": "0x4E43773D3A3aca08449fe18D3f26759CD43CBC2b",
+      "kind": "transparent",
+      "txHash": "0x7de0fb262d136bfb59a1230c11606d6ff63d3d57e8b58a5be10136f9772d5d21"
+    },
+    {
+      "address": "0x5D74e15E36492a9CC6fda503b3cFf0CA10d90a83",
+      "kind": "transparent",
+      "txHash": "0x1c5426a3c3a6d1ab11036191b9313ba65e4d65e1f6a0542ced6ddeba67ca3259"
+    },
+    {
+      "address": "0x314B40e9232177AB0B54E874A7d351c781eFe44d",
+      "kind": "transparent",
+      "txHash": "0x6b7b3b904855ca6a6d32b3f011c3eaefea644e87609c254ae2668d38a1191790"
+    },
+    {
+      "address": "0xeB80313502EA077FA9B8E89b45e4a1B236cA17Ea",
+      "kind": "transparent",
+      "txHash": "0xba4977e7aa29aef5762855d9ac1710c29676a24705018c3c72bc83bd70c42a6f"
+    },
+    {
+      "address": "0xB8054085AF605D93c32E6B829d3d7eA2A8C84F9A",
+      "kind": "transparent",
+      "txHash": "0xf0a6dd7679ad6fca8504374dce2e088e65df48a0dc41301c16089c70bd587d37"
+    },
+    {
+      "address": "0xc495aF5b4eAeAa0916861eB1985400bae973F110",
+      "kind": "transparent",
+      "txHash": "0x147aa9c9343d4e69cd302feb3ae5e6034b4af44109b670d2dcaf4fd3ab07ebd9"
+    },
+    {
+      "address": "0x8b949D7E587518A6ad727ef30C5815De4a16A0D7",
+      "kind": "transparent",
+      "txHash": "0x1f8850117bf1208df0009b50b75ef50fa57761278dfa32374ae75bbbc961d63b"
+    },
+    {
+      "address": "0x95A1C22E8A89f7b3cCa63a9ea3c064E72C96CAa0",
+      "kind": "transparent",
+      "txHash": "0x78f9d311dfc6d98e86bd27bd861bfdb825ca3248d6e30e4b137f8868f68de893"
+    },
+    {
+      "address": "0x2F224F22dE1D1adFece39B1939490d9DEAfBfF57",
+      "kind": "transparent",
+      "txHash": "0xe0d0629ea4efff91a4a518a8ef18be289f9752a4e6230fa840764a05d68e5a58"
+    },
+    {
+      "address": "0x50493e948b3907F34da285f4cc85C2CFE0Cb752F",
+      "kind": "transparent",
+      "txHash": "0xfbb5547997ed759f41cfc58416b08734440dc30d10cacdf042eccd9e44bf155c"
+    },
+    {
+      "address": "0xb3a9b7B5728416227cB09d047fAE2Df36Df04819",
+      "kind": "transparent",
+      "txHash": "0xa114a28d6cb9564e4fe98c46cb105e8cf9422b5046d82c534a7de1fd010f9723"
+    },
+    {
+      "address": "0x0b4789F2aB956463b3cEadE041CAC04D8b95a792",
+      "kind": "transparent",
+      "txHash": "0xe0c3fdc8b6efb9468a805e7ac83dd50b4043d94931628ac0e90e700f9f04e80b"
+    },
+    {
+      "address": "0x84d1CE12E078B2901985804c603d343cA3a1c875",
+      "kind": "transparent",
+      "txHash": "0x07293c59862f219f96b385e008dc38c0e2d032562e847c9b15aed068f2b9f215"
+    },
+    {
+      "address": "0xFe230c227D3724015d0dE3dBEc831825f1ed1f59",
+      "kind": "transparent",
+      "txHash": "0x36a564436fd8ab699949f15c0bc482a188f947f9e6daab3eb0de8b80aa55b477"
+    },
+    {
+      "address": "0xd44937448A9f229bfae84e7d256810Ba4C4a93cC",
+      "kind": "transparent",
+      "txHash": "0x1e3e75f529368fd5d3d9972865c1bffcacdf1cc012b8fc203459ab4fb8986ff4"
+    },
+    {
+      "address": "0x96049b850bE3415b4d7DcFECA2e6eE02ee580488",
+      "kind": "transparent",
+      "txHash": "0x8d713142faff6cf28d4e48d6b259959a189fb3065c5a18de6698cf2500b97770"
+    },
+    {
+      "address": "0xC41655Fb8aCA57544a1CD799d49FCb8e5703BE7A",
+      "kind": "transparent",
+      "txHash": "0xaa191dd58ccdcc77054acace68d9e61ca45c706e9f62da8c255327248b5451d5"
+    },
+    {
+      "address": "0xe5a5a5b78F165C875EE2264a8743570176eA39d9",
+      "kind": "transparent",
+      "txHash": "0x32beac77d5e4731296dc19be0503083a3d4a7ee4d7e32294a2fbff6a2dfb8bcb"
+    },
+    {
+      "address": "0xAb35dEf6f863FC1e91dE4c20A3596b388eB1CFb4",
+      "kind": "transparent",
+      "txHash": "0x9a76d009b029696dceb5fe36ec10ab1d0dd9056c278f4f6e809b4b78c38470cb"
+    },
+    {
+      "address": "0x5f687ea375c359E0CF6aa8A1004BE0c3BaBee7Fd",
+      "kind": "transparent",
+      "txHash": "0x64c632391673216283e3dca0e64702899cfe0bebc771f6025783fe71b71b47ad"
+    },
+    {
+      "address": "0xB660Fdd109a95718cB9d20E3A89EE6cE342aDcB6",
+      "kind": "transparent",
+      "txHash": "0xe821e6983a846ace73876df34e62eab30c7cd1291c0634e01631d816d5eb7896"
+    },
+    {
+      "address": "0xA0AB1cB92A4AF81f84dCd258155B5c25D247b54E",
+      "kind": "transparent",
+      "txHash": "0xe406d7238363cfa22ffa29d8d0bea2c7608ebbd2948f65331f35650aa305c39c"
+    },
+    {
+      "address": "0xE91bBe8ee03560E3dda2786f95335F5399813Ca0",
+      "kind": "transparent",
+      "txHash": "0xb03e639ada8a1efe96db0ed68f07e50471c45e76a64720061cd32c0e9b7a844f"
+    },
+    {
+      "address": "0x4977FC58783ceBCC310311C800B786EcAf45F98f",
+      "kind": "transparent",
+      "txHash": "0x33b450e1fb717b73685e832b68139a7166e3fabf8c1f092bebe66a06b2865b29"
+    },
+    {
+      "address": "0x20CbDcC1d471D4c41382eD6013d9561070C3eD48",
+      "kind": "transparent",
+      "txHash": "0xe56565429da24b5b095837b30b8c5f36a850fcf40019bee9efcc4ccc4d964665"
+    },
+    {
+      "address": "0xbC7Ab6F930D83CB7e80A207d4dD3DD80aA8a2153",
+      "kind": "transparent",
+      "txHash": "0x00a8573fa60080b05e8c6a4a86637d367338b21914a37b874779adb952755963"
+    },
+    {
+      "address": "0x7997A4c8b8E97d289989431B996AB1C6a9975Ad9",
+      "kind": "transparent",
+      "txHash": "0xcc80b0dec6d3a2333a4aada282c59fe8168ef7148bcf608779af3af1928e94f0"
+    },
+    {
+      "address": "0xb1DcE3617838AcbCa7f9CC84d475eF4414d92C06",
+      "kind": "transparent",
+      "txHash": "0xbb67ba94ef8e6f58020e2d517a48eeec5709237b010f3fb066e19c74a72b01b7"
+    },
+    {
+      "address": "0xc783bfC59158E888dA3E9c7768aaDC7a58ee7809",
+      "kind": "transparent",
+      "txHash": "0x7c1603bbbf31d37d38b587c00c136f8b42265aee046dd78277824538bc904844"
+    },
+    {
+      "address": "0xBdFE372Bb5a0db801A1a17796EC5cfF2F30A714C",
+      "kind": "transparent",
+      "txHash": "0x1d591402ab150221c58e8872ed2f85a1a75c8e49bb11104db0877c3d17ab7f30"
+    },
+    {
+      "address": "0xD325d114a728C2114Bd33Ad47152f790f2a29c5c",
+      "kind": "transparent",
+      "txHash": "0x588ce208328d9ccd5cde719832dccf4551faec7d2aa8dd13dad089624a0fd49c"
+    },
+    {
+      "address": "0x910b6a78b413e47401f20aA2350d264b55ae0189",
+      "kind": "transparent",
+      "txHash": "0xbac31ef58fb15c8a53ed3c8e7ad817755160b6d5d1b6f37d39c0757838137aed"
+    },
+    {
+      "address": "0x587BF1Bc96163E279D2Ea1b27F3b41cC34b171C3",
+      "kind": "transparent",
+      "txHash": "0x1e145a083abcd5cdd474b16596b7ed417459aaa1e14295cbdf1f99c93c6c85a4"
+    },
+    {
+      "address": "0xFb6888b081b6A32A18cD7Dd77238207DB51450BB",
+      "kind": "transparent",
+      "txHash": "0x3dc75b1b4cf7aac5f8c8e76063af6ec9749b32f46ed9a787ed5a6c66db9b807d"
+    },
+    {
+      "address": "0x4fE09fd873d2E21045d25f6aC3eBcC578b3FE33D",
+      "kind": "transparent",
+      "txHash": "0xbf28b644b4b879a5e0a1a1c325d2fe5f03ba83569b9d91a266e19e30beb33ffe"
+    },
+    {
+      "address": "0x6Ac05758229c725A6d14F0ae7088985D9B251Fb2",
+      "kind": "transparent",
+      "txHash": "0x58d412af88e32ee306f56ee6276361c7746c7af4e5ffa3e1523cddd921138dac"
+    },
+    {
+      "address": "0xb2B548BE73010C188C083c510d255Aed74843b05",
+      "kind": "transparent",
+      "txHash": "0x36437519384b51c73a869acc46c48fd630ebe9171ae19b88b56b084dbec01759"
+    },
+    {
+      "address": "0x5Ea694f66BD0CBd08FC7967af01b67Dcef68cC5c",
+      "kind": "transparent",
+      "txHash": "0x085643dd9c83bfe7555aeaa5f8929d7a3a0daa01c852915a3afc66f403bcc7a5"
+    },
+    {
+      "address": "0x8280D40C9E9F04229D2435EAad6e0011309ce81B",
+      "kind": "transparent",
+      "txHash": "0xff7ad8d07a7a6c3de4f361f2547dc26e23db5ae0f8756caca436a4686843356b"
+    },
+    {
+      "address": "0xBEF0d4b9c089a5883741fC14cbA352055f35DDA2",
+      "kind": "transparent",
+      "txHash": "0xa8a8cea715a2896c58e91ad60ba10e6bae6ed54fcca960d024f434dbcd850439"
+    },
+    {
+      "address": "0x2cfcA5785261fbC88EFFDd46fCFc04c22525F9e4",
+      "kind": "transparent",
+      "txHash": "0x50cc31125c45dcb0eccc83f1f734c08058b0eaf2359ec3c702d34bd87f749b6b"
+    },
+    {
+      "address": "0xde9595927B00361Ed7987a181Fb09EC6f31b451c",
+      "kind": "transparent",
+      "txHash": "0x288cdd1b96aa9cedd256a6d44e88dac30ee07de70b82327ca57167b7be62a06a"
+    },
+    {
+      "address": "0x392E5355a0e88Bd394F717227c752670fb3a8020",
+      "kind": "transparent",
+      "txHash": "0x6861eaec62cbf55a2e0143394c5b28d572c27c2f243721946cd4fe64d1414adb"
+    },
+    {
+      "address": "0xEBAB67ee3ef604D5c250A53b4b8fcbBC6ec3007C",
+      "kind": "transparent",
+      "txHash": "0xf0d606df7fb5a5572a0916fd2141b224ac6b2b03206c53ca9f596fa851abc5b0"
+    },
+    {
+      "address": "0xD67ba212bA61226DF3d20B2bD92deD3A6770f32d",
+      "kind": "transparent",
+      "txHash": "0xbe1546488c5ca18716f9ad5627d036969294d54e048fc1c850c38bddb4c03c4f"
+    },
+    {
+      "address": "0x6aaF7e94e099291a94ed8E245c90f4766CE9bB7C",
+      "kind": "transparent",
+      "txHash": "0x3e2ca720e7a09d9693c6465d967118b3f603cd21513eb65193edba31fa7ad488"
+    },
+    {
+      "address": "0xcdF1185e592AFc8d8754C4BC8479C39b20437E42",
+      "kind": "transparent",
+      "txHash": "0xbdba99af8cd5708a14ea36c2fce3667a5f6db4aa15996bdd3d229191e8d24f83"
+    },
+    {
+      "address": "0xAA15a22Fcf42465dC3F9C3238Cd7fB69dba86499",
+      "kind": "transparent",
+      "txHash": "0x7aa5be68ff17db5e54a1cb31203fee79fafad74f3e5470d9b9660f1435d19f42"
+    },
+    {
+      "address": "0x821503f2d6990eb6E71fde0CeFf503cE5415b98c",
+      "kind": "transparent",
+      "txHash": "0x335ca6666a1626898c3f47affd612c73dd6a8d68a554d797fc3a16b03ce64d44"
+    },
+    {
+      "address": "0xC5f7aC6895DcB76877E71db756433fB0E0478FEB",
+      "kind": "transparent",
+      "txHash": "0x92ec1eec58e6cf82cc6d0fc1a7af0d183c9b07c348ee356b2cb0ff7a269423cf"
+    },
+    {
+      "address": "0x4b2c297ba5be42610994974b9543D56B864CA011",
+      "kind": "transparent",
+      "txHash": "0xc7e9fd15067162167c9e948d0119220e14d649bf4ee0f6b66be9b2ef003dafb1"
+    },
+    {
+      "address": "0x285671fF5C8172dE63cF5eA264B2e827aDBC6740",
+      "kind": "transparent",
+      "txHash": "0xca97dc5de2c918b4bf9de01488f77dce86e5f28a3157594c0a1c2f40ecd99288"
+    },
+    {
+      "address": "0x1a432D97211e8b2CD53DF262c8Da0EfeBa6b6b3D",
+      "kind": "transparent",
+      "txHash": "0x50b3f2e654f62d31c188ed56e200e2b5d4680a9bc8a169ef814ca1508fa4f9d5"
+    },
+    {
+      "address": "0x5c98c9202b73d27A618662d34A6805c34AB041B8",
+      "kind": "transparent",
+      "txHash": "0xe85508da1887311b8928db13a889405332b0259cbd3f5eddd80c5c92c052a93e"
+    },
+    {
+      "address": "0xBE7fFcC01164C890e59D298FD755FcBE6B7941a9",
+      "kind": "transparent",
+      "txHash": "0x0de4602624152a566babe1f808930e64ddcbd33ffe935ff49304fe73fc544b1f"
+    },
+    {
+      "address": "0x7cFdBc7907cb4d1d27DcE75609be7dfe8a4F1340",
+      "kind": "transparent",
+      "txHash": "0x12d4f44209e7e60630cdee99ac9c28a722cca09c4cabf679973a62e818bd5805"
+    },
+    {
+      "address": "0x22B37db37e9992728245A7dD0536892AF9bA1baB",
+      "kind": "transparent",
+      "txHash": "0x564d3031686f258eb1c125a8ebfbe8c70f7ec12c8bb128283f57359533da40d8"
+    },
+    {
+      "address": "0x2005823e074313cd644035557bF4FFa0ca0Bddff",
+      "kind": "transparent",
+      "txHash": "0x1ea790300a9c988399f38e25e262e3e60311ceb3e0adc596f1c053b75e87384e"
+    },
+    {
+      "address": "0x22058276Dd278bD037591805E62E797012d666f6",
+      "kind": "transparent",
+      "txHash": "0x653bb192513600f03dabe14b7d9cc97e71d9aa85bab73d66db8e3f5abe65c972"
+    }
+  ],
+  "admin": {
+    "address": "0x3619DbE27d7c1e7E91aA738697Ae7Bc5FC3eACA5",
+    "txHash": "0x7b87f110b098412f45701a5601e9e5c8d7a7d56592ca2451f1a72ee166a9c914"
+  }
+}

--- a/client/src/contracts/TokenProxyFactory.sol
+++ b/client/src/contracts/TokenProxyFactory.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.8.2;
+
+import {ClonesUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
+import "./ProductToken.sol";
+
+contract TokenProxyFactory { 
+
+	address public owner;
+	address daiAddress;
+    address public impContract;
+	mapping(string => address) registry;
+
+	constructor(address _daiAddress,address _impContract) public {
+		owner = msg.sender;
+		daiAddress = _daiAddress;
+        impContract=_impContract;
+	}
+
+	modifier onlyOwner {
+        require(
+            msg.sender == owner,
+            "Only owner can call this function."
+        );
+        _;
+  }
+
+	// function initialize() public initializer {
+
+	// }
+
+	function createTokenProxy(string memory _productName, bytes memory _data) public onlyOwner returns (address) {
+		require(registry[_productName]==address(0), "The product token already exist");
+		address newProxyToken = ClonesUpgradeable.cloneDeterministic(impContract, _data);
+		registry[_productName] = newProxyToken;
+		return newProxyToken;
+	}
+
+	function retrieveToken(string memory _productName) public view returns(address) {
+		require(registry[_productName]!=address(0), "This product token does not exist");
+		return registry[_productName];
+	}
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "devDependencies": {
     "@openzeppelin/truffle-upgrades": "^1.5.2",
+    "@openzeppelin/upgrades": "^2.8.0",
     "chai": "^4.3.4",
-    "chai-bn": "^0.2.1"
+    "chai-bn": "^0.2.1",
+    "zos-lib": "^2.4.3"
   }
 }

--- a/test/Token.proxy.factory.test.js
+++ b/test/Token.proxy.factory.test.js
@@ -1,0 +1,40 @@
+const TokenProxyFactory = artifacts.require('TokenProxyFactory');
+const { deployProxy } = require('@openzeppelin/truffle-upgrades');
+const ProductToken = artifacts.require('ProductToken');
+const encodeCall = require('zos-lib/lib/helpers/encodeCall').default;
+
+contract('TokenProxyFactory', function (accounts) {
+	const exp = 330000				// assuming price function exponential factor of 2, input reserve ratio in ppm
+	const max = 500						// assuming max 500 token will be minted
+	const offset = 10
+	const baseReserve = web3.utils.toWei('0.33', 'ether')
+	let imp
+  let proxyFactory
+    beforeEach(async function () {
+      imp  = await deployProxy(ProductToken, [exp, max, offset, baseReserve], {initializer: 'initialize'});
+      proxyFactory = await TokenProxyFactory.new(imp.address,imp.address);
+    });
+    it('it should return logicContract', async function () {
+     const address = await proxyFactory.impContract.call();
+     assert.equal(address, imp.address);
+    });
+    it('it should createTokenProxy ', async function () {
+      initializeData = encodeCall(
+        'initialize', 
+        ['uint32', 'uint32','uint32','uint256'],   
+        [exp, max,offset,baseReserve]
+      );
+      const proxyAddress = await     
+      proxyFactory.createTokenProxy.call(
+        "HighGO",initializeData,
+      );
+      const impl = await ProductToken.deployed(proxyAddress);
+      const reserveRatio = await impl.reserveRatio.call();
+      const maxTokenCount =await impl.maxTokenCount.call();
+      const supplyOffset =await impl.supplyOffset.call();
+      assert.equal(exp, reserveRatio);
+      assert.equal(max, maxTokenCount);
+      assert.equal(offset, supplyOffset);
+    });
+  
+  });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -44,7 +44,8 @@ module.exports = {
     //
     development: {
      host: "127.0.0.1",     // Localhost (default: none)
-     port: 7545,            // Standard Ethereum port (default: none)
+    //  port: 7545,            // Standard Ethereum port (default: none)
+    port:8545,
      network_id: "*",       // Any network (default: none)
     },
     
@@ -92,7 +93,7 @@ module.exports = {
          enabled: true,
          runs: 200
        },
-       evmVersion: "byzantium"
+      //  evmVersion: "byzantium"
       }
     }
   },


### PR DESCRIPTION
I added TokenProxyFactory
 "@OpenZeppelin/Upgrades" does not support 0.8.2
But I found some ways
@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol
To modify Yul code

function cloneDeterministic(address implementation, bytes memory _data) internal returns (address instance) {
        // solhint-disable-next-line no-inline-assembly
        assembly {
            let ptr := mload(0x40)
            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
            mstore(add(ptr, 0x14), shl(0x60, implementation))
            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
            instance := create2(0, ptr, 0x37, 0x37)
        }
        require(instance != address(0), "ERC1167: create2 failed");

        if(_data.length > 0) {
            (bool success,) = instance.call(_data);
            require(success);
        }    
    }

0.8.2 create2() Instead of create() 

more add Token.proxy.factory.test.js

some TokenProxyFactory test case.

